### PR TITLE
ClientRequesterController setup

### DIFF
--- a/SKELETON-KING/Program.cs
+++ b/SKELETON-KING/Program.cs
@@ -5,8 +5,10 @@ public class Program
     public static void Main(string[] args)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddControllers();
 
         var app = builder.Build();
+        app.MapControllers();
         app.Run();
     }
 }

--- a/TRANSMUTANSTEIN/ClientRequesterControllerTest.cs
+++ b/TRANSMUTANSTEIN/ClientRequesterControllerTest.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ZORGATH;
+
+namespace TRANSMUTANSTEIN;
+
+[TestClass]
+public class ClientRequesterControllerTest
+{
+    private class TestClientRequesterHandler : IClientRequesterHandler
+    {
+        private readonly IActionResult _result;
+        public TestClientRequesterHandler(IActionResult result)
+        {
+            _result = result;
+        }
+
+        public Task<IActionResult> HandleRequest(ControllerContext controllerContext, Dictionary<string, string> formData)
+        {
+            return Task.FromResult(_result);
+        }
+    }
+
+    [TestMethod]
+    public async Task HandlerIsInvoked()
+    {
+        IActionResult expected = new OkResult();
+
+        // Register our fake ClientRequesterHandler.
+        Dictionary<string, IClientRequesterHandler> handlers = new()
+        {
+            ["test"] = new TestClientRequesterHandler(expected)
+        };
+        ClientRequesterController controller = new(handlers);
+
+        Dictionary<string, string> formData = new()
+        {
+            ["f"] = "test"
+        };
+
+        // Trigger our fake ClientRequesterHandler.
+        var actual = await controller.ClientRequester(formData);
+        Assert.AreSame(expected, actual);
+    }
+
+    [TestMethod]
+    public async Task UnknownRequest()
+    {
+        ClientRequesterController controller = new(new Dictionary<string,IClientRequesterHandler>());
+        Dictionary<string, string> formData = new()
+        {
+            ["f"] = "test2"
+        };
+
+        // Trigger an unknown request.
+        var actual = await controller.ClientRequester(formData);
+        Assert.IsInstanceOfType(actual, typeof(BadRequestObjectResult));
+    }
+
+    [TestMethod]
+    public async Task UnspecifiedRequest()
+    {
+        ClientRequesterController controller = new(new Dictionary<string, IClientRequesterHandler>());
+        Dictionary<string, string> formData = new();
+
+        // Trigger an unspecified request.
+        var actual = await controller.ClientRequester(formData);
+        Assert.IsInstanceOfType(actual, typeof(BadRequestObjectResult));
+    }
+}

--- a/TRANSMUTANSTEIN/TRANSMUTANSTEIN.csproj
+++ b/TRANSMUTANSTEIN/TRANSMUTANSTEIN.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 

--- a/ZORGATH/ClientRequesterController.cs
+++ b/ZORGATH/ClientRequesterController.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ZORGATH;
+
+[ApiController]
+[Route("client_requester.php")]
+[Consumes("application/x-www-form-urlencoded")]
+
+public class ClientRequesterController : ControllerBase
+{
+    private readonly IReadOnlyDictionary<string, IClientRequesterHandler> _clientRequesterHandlers;
+
+    public ClientRequesterController(IReadOnlyDictionary<string,IClientRequesterHandler> clientRequesterHandlers)
+    {
+        _clientRequesterHandlers = clientRequesterHandlers;
+    }
+
+    [HttpPost(Name = "Client Requester")]
+    public async Task<IActionResult> ClientRequester([FromForm] Dictionary<string, string> formData)
+    {
+        // Client requester has two forms for function identifiers. Some are
+        // part of the query in the format `client_requester.php?f=`. Others
+        // are specified as the `f` parameter in the `formData`.
+        if (!formData.TryGetValue("f", out string? functionName))
+        {
+            var request = Request;
+            if (request != null && request.Query.TryGetValue("f", out var value))
+            {
+                // API returns a collection in case the parameter is specified more than once.
+                functionName = value[0];
+            }
+        }
+
+        if (functionName == null)
+        {
+            // Unspecified request name.
+            return BadRequest("Unknown request.");
+        }
+
+        if (_clientRequesterHandlers.TryGetValue(functionName, out var requestHandler))
+        {
+            return await requestHandler.HandleRequest(ControllerContext, formData);
+        }
+
+        // Unknown request name.
+        Console.WriteLine("Unknown request '{0}'.", functionName);
+        return BadRequest(functionName);
+    }
+}

--- a/ZORGATH/IClientRequesterHandler.cs
+++ b/ZORGATH/IClientRequesterHandler.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ZORGATH;
+
+/// <summary>
+///    Interface for a `client_requester.php` function request handlers.
+/// </summary>
+public interface IClientRequesterHandler
+{
+    /// <summary>
+    ///    Handles a `client_requester.php` request with the given `formData`
+    ///    and returns the appropriate result.
+    /// </summary>
+    public Task<IActionResult> HandleRequest(ControllerContext controllerContext, Dictionary<string, string> formData);
+}

--- a/ZORGATH/ZORGATH.csproj
+++ b/ZORGATH/ZORGATH.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Defines ClientRequesterController which delegates individual requests to set of IClientRequestHandler, defined as a Dictionary.
Basic unittest tests that the requests are forwarded correctly.