### PR TITLE
Implement PHP Serializer improvements

### DIFF
--- a/TRANSMUTANSTEIN/PHPTest.cs
+++ b/TRANSMUTANSTEIN/PHPTest.cs
@@ -43,7 +43,7 @@ public class PHPTest
             ["long_max"] = long.MaxValue
         };
         Assert.AreEqual(
-            "a:10:{s:10:\"account_id\";i:12345;s:12:\"account_name\";s:7:\"Maliken\";s:4:\"null\";N;s:1:\"0\";b:0;s:6:\"double\";d:1.7976931348623157E+308;s:5:\"float\";f:3.4028234663852886E+38;s:8:\"long_min\";i:-9223372036854775808;s:8:\"long_pos\";i:123;s:8:\"long_neg\";i:-123;s:8:\"long_max\";i:9223372036854775807;}",
+            "a:10:{s:10:\"account_id\";i:12345;s:12:\"account_name\";s:7:\"Maliken\";s:4:\"null\";N;s:1:\"0\";b:0;s:6:\"double\";d:1.7976931348623157E+308;s:5:\"float\";d:3.4028234663852886E+38;s:8:\"long_min\";i:-9223372036854775808;s:8:\"long_pos\";i:123;s:8:\"long_neg\";i:-123;s:8:\"long_max\";i:9223372036854775807;}",
             PHP.Serialize(dictionary));
     }
 
@@ -74,9 +74,7 @@ public class PHPTest
     [TestMethod]
     public void NullableProperties()
     {
-        Assert.AreEqual(
-            "a:7:{s:1:\"b\";N;s:1:\"i\";N;s:1:\"l\";N;s:1:\"d\";N;s:1:\"s\";N;s:4:\"dict\";N;s:1:\"o\";N;}",
-            PHP.Serialize(new Nullable()));
+        Assert.AreEqual("a:0:{}", PHP.Serialize(new Nullable()));
     }
 
     [TestMethod]
@@ -107,5 +105,102 @@ public class PHPTest
             123
         };
         Assert.AreEqual("a:1:{i:0;i:123;}", PHP.Serialize(list));
+    }
+
+    [TestMethod]
+    public void SerializeEnum()
+    {
+        // Enums should serialize as ints
+        List<AccountType> listOfEnums = new()
+        {
+            AccountType.Staff
+        };
+        List<int> listOfInts = new()
+        {
+            (int)AccountType.Staff
+        };
+        Assert.AreEqual(PHP.Serialize(listOfInts), PHP.Serialize(listOfEnums));
+    }
+
+    [TestMethod]
+    public void SerializeUTF8()
+    {
+        string utf8 = "coup de grâce";
+        Assert.AreEqual("s:14:\"coup de grâce\";", PHP.Serialize(utf8));
+    }
+
+    class StaticProperties
+    {
+        public static int Field;
+        public static int Property { get; set; } 
+    }
+
+    [TestMethod]
+    public void StaticPropertiesAreNotSerialized()
+    {
+        StaticProperties.Field = 1;
+        StaticProperties.Property = 2;
+        StaticProperties data = new();
+        Assert.AreEqual("a:0:{}", PHP.Serialize(data));
+    }
+
+    class PrimitiveValues
+    {
+        public readonly bool b = true;
+        public readonly int i = 2;
+        public readonly long l = 3;
+        public readonly double f = 4.5f;
+        public readonly double d = 6.7;
+        public readonly string s = "str";
+    }
+    [TestMethod]
+    public void SerializePrimitiveValues()
+    {
+        Assert.AreEqual("a:6:{s:1:\"b\";b:1;s:1:\"i\";i:2;s:1:\"l\";i:3;s:1:\"f\";d:4.5;s:1:\"d\";d:6.7;s:1:\"s\";s:3:\"str\";}", PHP.Serialize(new PrimitiveValues()));
+    }
+
+    [TestMethod]
+    public void SerializeStringArray()
+    {
+        string[] array = new string[] { "1", "2", "3" };
+        Assert.AreEqual("a:3:{i:0;s:1:\"1\";i:1;s:1:\"2\";i:2;s:1:\"3\";}", PHP.Serialize(array));
+    }
+
+    [TestMethod]
+    public void SerializeObjectArray()
+    {
+        PrimitiveValues?[] array = new PrimitiveValues?[1] { null };
+        Assert.AreEqual("a:1:{i:0;N;}", PHP.Serialize(array));
+    }
+
+    [TestMethod]
+    public void RareCollectionType()
+    {
+        Dictionary<long, long> d = new()
+        {
+            [42] = 24
+        };
+        Assert.AreEqual("a:1:{i:0;i:42;}", PHP.Serialize(d.Keys));
+        Assert.AreEqual("a:1:{i:0;i:24;}", PHP.Serialize(d.Values));
+    }
+
+    [TestMethod]
+    public void SerializeHashSetOfInts()
+    {
+        HashSet<int> h = new()
+        {
+            42
+        };
+        Assert.AreEqual("a:1:{i:0;i:42;}", PHP.Serialize(h));
+    }
+
+    [TestMethod]
+    public void SerializeHashSetOfStrings()
+    {
+        HashSet<string> h = new()
+        {
+            "test"
+        };
+        Assert.AreEqual("a:1:{i:0;s:4:\"test\";}", PHP.Serialize(h));
     }
 }

--- a/ZORGATH/AccountType.cs
+++ b/ZORGATH/AccountType.cs
@@ -1,0 +1,9 @@
+﻿namespace ZORGATH;
+
+public enum AccountType
+{
+    Disabled = 0,
+    Normal = 3,
+    Legacy = 4,    // User prepaid for their account during the Beta.
+    Staff = 5,
+}


### PR DESCRIPTION
- skip serializing null values. From the client perspective, lack of field is the same as presence of a field with null value.
- allow serializing enums. They are serialized using their integer representation.
- allow proper serialization of multi-byte strings (requiring more than one byte per character).