### PR TITLE
Reduce number of SQL queries made upon login by one

### DIFF
--- a/TRANSMUTANSTEIN/SrpAuthHandlerTest.cs
+++ b/TRANSMUTANSTEIN/SrpAuthHandlerTest.cs
@@ -28,7 +28,7 @@ public class SrpAuthHandlerTest
         string hashedPassword = "45b9467c354f712fa8b6175f6b6e82da5cb09a90fcfbda1e1d053dfc6aa41f5a";
         ConcurrentDictionary<string, SrpAuthSessionData> srpAuthSessions = new()
         {
-            [loginName] = new(loginName: loginName, clientPublicEphemeral: clientPublicEphemeral, salt: salt, passwordSalt: passwordSalt, hashedPassword: hashedPassword)
+            [loginName] = new(loginName: loginName, clientPublicEphemeral: clientPublicEphemeral, salt: salt, passwordSalt: passwordSalt, hashedPassword: hashedPassword, accountDetails: null!)
         };
         SrpAuthHandler srpAuthHandler = new(srpAuthSessions, new());
         Dictionary<string, string> formData = new()
@@ -38,33 +38,6 @@ public class SrpAuthHandlerTest
         };
         IActionResult result = await srpAuthHandler.HandleRequest(new ControllerContextForTesting(), formData);
         Assert.IsInstanceOfType(result, typeof(UnauthorizedObjectResult));
-    }
-
-    [TestMethod]
-    public async Task TestSrpAuthAccountIsMissing()
-    {
-        string loginName = "SouL";
-        string clientPublicEphemeral = "2cf2668bf9d0e2358d43d41ea7ba3152e62f953519999ed8bf7ac94066c3974d2784e82d0e2841329d1188ebe8fa24ddab46a95e4882f801933ce2e4d3329d48fad794998429aa73786f2c6e0a8080672a7840ebfdb0135dc1276a04948a51a26785ddb64dc14e796c759c8a17368290ffdc6fe228c0fdf6b3a6e125cc4fbc532ee61442f6b2f8c44b7f288b60861d132aead63d8163c3bcf8f2651e47a600894a37997f2f9b9d273f1a82c6d4db545b78c882df45b79e4f05bb3bcaa4f0a58e6ed629a30f4b409627cef5a3943e8b342e2b9632099683b2f228c0b8c7086eaccd424b3c22df1fa599320ff21ee2510b4952a0a856bd0a6cf7cfd524fa5110e4";
-        string salt = "078f6068db52fd1cea4db48789b3ce8bfb47fdb33d4767d0c86e35104a5d8ad511aa18624529bc3176697a4f366098aa016464cfcdf3b8acd620ecf5bd553e98ff4364b8f39ef6ffd2893bf80e681cd00d9622c1270ce2ddb681ab097c713429d5875566e2ef1934abb99d870ddf83f74be33b4b3ba22f7dd93b50057c45d5fe47a49539c61178d4c06748d5519433bd62e9f083bd59bbb4ed4f3a8b3fffb0895e07e07230445ec64fabc9a4e27c975012b9f78922beff6759150312d8b0fab25afbb363a2ed9810d6d1180636b0f886fc74dbba51f89389df06405308d7d9f0c2c2775985ae71c03337b0ecb938b327d8883e506632260962f8223d2f2865e2";
-        string passwordSalt = "205cd38bd6ea0017322406";
-        string verifier = "b0c856d02fc81d6e89d4ed0f6ab6f2b594349dc570c71b0182350568a55a78c082d515b30841ed28b4c72dd32d3cbb873ef7d9febf0c0f1f3a3870c90925b20ec88fcbdbbc89d5a1f8a7cf4c1c30c6c8428f031b1aa782bb8e0751f14998ba50364029a82344b48bd533c9c95a5e95211ea12cb0248ce3b21a974af4deb1a9cbe044d0b0df9aef81ad0a0424765ed4a2c22339c75dc0930e6768a2e59fb9bb7eee7da41e631c8a0cb8668efdd0f05b6050b90afa6dce4eab952c075f8d50809f9fe21dc230129a6ee9721e5a2adcf100bfe44c3cd672339cfbaf0f921523f901e3b5e5b53404c651d1f852b0f839520ca5f3f054e9b49651a8600031af54d7ee";
-        SrpEphemeral serverEphemeral = new()
-        {
-            Public = "0f61bb9848afeeff12d24f3c1e37accb55fb702022df75c839028f06ec8b11fe0555f7ded43fbfd1d2062eca65093f35564c969a3494a7ed8d68c626e2e50b379f28f9a5cb65c2adac61080c2df78bec8d91ca416f2bcaf5a5d71e7f251fc28f31644ae61f746ba5d2449edf86f50d365a810921fab85ad7db9a815729b3d1731935d9accf07b3f7db8477b76ee7b4e7cc7cd08e4ca9ef60101cbb89c239676a67dc15fa849f6ec856ba04caf359d63ad17ea7444f3fc043a8fb26e8879c6b1b5fd51127c8e6c727c9badec4b2397dd40d38029b74262549d7282237aa95ad51c6dc1b2bef20d7b8726dbaa6c915a9747956f32c2a5c1bff1dbf4b3946636efb",
-            Secret = "d7f620e7b625bc907374d2c92ed3d399827e2ba025a89227394135e74b38db3a"
-        };
-        ConcurrentDictionary<string, SrpAuthSessionData> srpAuthSessions = new()
-        {
-            [loginName] = new(clientPublicEphemeral: clientPublicEphemeral, salt: salt, passwordSalt: passwordSalt, verifier: verifier, serverEphemeral: serverEphemeral)
-        };
-        SrpAuthHandler srpAuthHandler = new(srpAuthSessions, new());
-        Dictionary<string, string> formData = new()
-        {
-            ["login"] = loginName,
-            ["proof"] = "6523fe0eca24f04c280d9f6b9e5a2d3bec18686d773efdc35ed8f0b4f9057ca6"
-        };
-        IActionResult result = await srpAuthHandler.HandleRequest(new ControllerContextForTesting(), formData);
-        Assert.IsInstanceOfType(result, typeof(NotFoundObjectResult));
     }
 
     [TestMethod]
@@ -80,9 +53,31 @@ public class SrpAuthHandlerTest
             Public = "0f61bb9848afeeff12d24f3c1e37accb55fb702022df75c839028f06ec8b11fe0555f7ded43fbfd1d2062eca65093f35564c969a3494a7ed8d68c626e2e50b379f28f9a5cb65c2adac61080c2df78bec8d91ca416f2bcaf5a5d71e7f251fc28f31644ae61f746ba5d2449edf86f50d365a810921fab85ad7db9a815729b3d1731935d9accf07b3f7db8477b76ee7b4e7cc7cd08e4ca9ef60101cbb89c239676a67dc15fa849f6ec856ba04caf359d63ad17ea7444f3fc043a8fb26e8879c6b1b5fd51127c8e6c727c9badec4b2397dd40d38029b74262549d7282237aa95ad51c6dc1b2bef20d7b8726dbaa6c915a9747956f32c2a5c1bff1dbf4b3946636efb",
             Secret = "d7f620e7b625bc907374d2c92ed3d399827e2ba025a89227394135e74b38db3a"
         };
+        AccountDetails accountDetails = new AccountDetails(
+            accountId: 1,
+            accountName: loginName,
+            accountType: AccountType.Legacy,
+            selectedUpgradeCodes: Array.Empty<string>(),
+            autoConnectChatChannels: Array.Empty<string>(),
+            ignoredAccountIds: Array.Empty<string>(),
+            accountStats: new(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            clanId: null,
+            clanName: null,
+            clanTag: null,
+            clanTier: Clan.Tier.None,
+            useCloud: false,
+            cloudAutoUpload: false,
+
+            // User-specific information.
+            userId: "fake-user-id",
+            email: "fake-email-address",
+            goldCoins: 12,
+            silverCoins: 23,
+            unlockedUpgradeCodes: Array.Empty<string>()
+        );
         ConcurrentDictionary<string, SrpAuthSessionData> srpAuthSessions = new()
         {
-            [loginName] = new(clientPublicEphemeral: clientPublicEphemeral, salt: salt, passwordSalt: passwordSalt, verifier: verifier, serverEphemeral: serverEphemeral)
+            [loginName] = new(clientPublicEphemeral: clientPublicEphemeral, salt: salt, passwordSalt: passwordSalt, verifier: verifier, serverEphemeral: serverEphemeral, accountDetails: accountDetails)
         };
         SrpAuthHandler srpAuthHandler = new(srpAuthSessions, new());
         Dictionary<string, string> formData = new()

--- a/ZORGATH/PreAuthHandler.cs
+++ b/ZORGATH/PreAuthHandler.cs
@@ -28,7 +28,50 @@ public class PreAuthHandler : IClientRequesterHandler
                 formData["A"],
                 account.User.Salt,
                 account.User.PasswordSalt,
-                account.User.HashedPassword))
+                account.User.HashedPassword,
+                new AccountDetails(
+                    account.AccountId,
+                    account.Name,
+                    account.AccountType,
+                    account.SelectedUpgradeCodes,
+                    account.AutoConnectChatChannels,
+                    account.IgnoredList,
+
+                    // TODO: query stats too.
+                    new AccountStats(
+                        /* level: */ 0,
+                        /* levelExp: */ 0,
+                        /* psr: */ 1500,
+                        /* normalRankedGamesMMR: */ 1500,
+                        /* casualModeMMR: */ 1500,
+                        /* publicGamesPlayed: */ 0,
+                        /* normalRankedGamesPlayed: */ 0,
+                        /* casualModeGamesPlayed: */ 0,
+                        /* midWarsGamesPlayed: */ 0,
+                        /* allOtherGamesPlayed: */ 0,
+                        /* publicGameDisconnects: */ 0,
+                        /* normalRankedGameDisconnects: */ 0,
+                        /* casualModeDisconnects: */ 0,
+                        /* midWarsTimesDisconnected: */ 0,
+                        /* allOtherGameDisconnects: */ 0),
+
+                    // Clan information.
+                    account.Clan!.ClanId,
+                    account.Clan!.Name,
+                    account.Clan!.Tag,
+                    account.ClanTier,
+
+                    // TODO: CloudStorage.
+                    /* useCloud: */ false,
+                    /* cloudAutoUpload: */ false,
+
+                    // User-specific information.
+                    account.User.Id,
+                    account.User.Email!,
+                    account.User.GoldCoins,
+                    account.User.SilverCoins,
+                    account.User.UnlockedUpgradeCodes
+                )))
             .FirstOrDefaultAsync();
         if (srpAuthSessionData is null)
         {

--- a/ZORGATH/SrpAuthSessionData.cs
+++ b/ZORGATH/SrpAuthSessionData.cs
@@ -12,7 +12,7 @@ public class SrpAuthSessionData
 
     public const string g = "2";
 
-    public SrpAuthSessionData(string loginName, string clientPublicEphemeral, string salt, string passwordSalt, string hashedPassword)
+    public SrpAuthSessionData(string loginName, string clientPublicEphemeral, string salt, string passwordSalt, string hashedPassword, AccountDetails accountDetails)
     {
         ClientPublicEphemeral = clientPublicEphemeral;
         Salt = salt;
@@ -25,15 +25,18 @@ public class SrpAuthSessionData
 
         SrpServer srpServer = new(parameters);
         ServerEphemeral = srpServer.GenerateEphemeral(Verifier);
+
+        AccountDetails = accountDetails;
     }
 
-    public SrpAuthSessionData(string clientPublicEphemeral, string salt, string passwordSalt, string verifier, SrpEphemeral serverEphemeral)
+    public SrpAuthSessionData(string clientPublicEphemeral, string salt, string passwordSalt, string verifier, SrpEphemeral serverEphemeral, AccountDetails accountDetails)
     {
         ClientPublicEphemeral = clientPublicEphemeral;
         Salt = salt;
         PasswordSalt = passwordSalt;
         Verifier = verifier;
         ServerEphemeral = serverEphemeral;
+        AccountDetails = accountDetails;
     }
 
     /**
@@ -59,4 +62,9 @@ public class SrpAuthSessionData
     public readonly string PasswordSalt;
 
     public readonly string Verifier;
+
+    /**
+     * Account data required for successfully completing arpAuth request.
+     */
+    public readonly AccountDetails AccountDetails;
 }


### PR DESCRIPTION
Currently, we are making up to 8 SQL queries during login flow:
1. pre_auth performs one query to lookup salt/passwordSalt etc
2. srpAuth looksup account details /
3. srpAuth then makes another 4 queries (5 if player in in a clan)
4. srpAuth then generates a new cookie and performs a query to save it.

This PR is attempting to eliminate one of the queries by merging queries 1. and 2. into a single query. While the pre_auth query will be more comples, srpAuth would have to perform one less query.

To do this, move AccountDetails lookup from SrpAuthHandler to PreAuthHandler and store it inside SrpAuthSessionData.