### PR TITLE
Switch from using a basic non-transactional in-memory db to an in-memory sqlite for the tests

### DIFF
--- a/TRANSMUTANSTEIN/AutoCompleteNicksHandlerTest.cs
+++ b/TRANSMUTANSTEIN/AutoCompleteNicksHandlerTest.cs
@@ -11,11 +11,12 @@ public class AutoCompleteNicksHandlerTest
         bountyContext.Accounts.Add(
             new Account()
             {
-                Name = "korDen"
+                Name = "korDen",
+                User = new("", "", ""),
             });
         await bountyContext.SaveChangesAsync();
 
-        AutoCompleteNicksHandler handler = new AutoCompleteNicksHandler();
+        AutoCompleteNicksHandler handler = new();
 
         Dictionary<string, string> formData = new()
         {
@@ -33,22 +34,26 @@ public class AutoCompleteNicksHandlerTest
     {
         ControllerContext controllerContext = new ControllerContextForTesting();
         using BountyContext bountyContext = controllerContext.HttpContext.RequestServices.GetRequiredService<BountyContext>();
+        ElementUser user = new("", "", "");
         bountyContext.Accounts.AddRange(
             new Account()
             {
-                Name = "korNy"
+                Name = "korNy",
+                User = user,
             },
             new Account()
             {
-                Name = "korDen"
+                Name = "korDen",
+                User = user,
             },
             new Account()
             {
-                Name = "mrhappyasthma"
+                Name = "mrhappyasthma",
+                User = user,
             });
         await bountyContext.SaveChangesAsync();
 
-        AutoCompleteNicksHandler handler = new AutoCompleteNicksHandler();
+        AutoCompleteNicksHandler handler = new();
 
         Dictionary<string, string> formData = new()
         {
@@ -66,18 +71,21 @@ public class AutoCompleteNicksHandlerTest
     {
         ControllerContext controllerContext = new ControllerContextForTesting();
         using BountyContext bountyContext = controllerContext.HttpContext.RequestServices.GetRequiredService<BountyContext>();
+        ElementUser user = new("", "", "");
         bountyContext.Accounts.AddRange(
             new Account()
             {
-                Name = "korDen"
+                Name = "korDen",
+                User = user,
             },
             new Account()
             {
-                Name = "mrhappyasthma"
+                Name = "mrhappyasthma",
+                User = user,
             });
         await bountyContext.SaveChangesAsync();
 
-        AutoCompleteNicksHandler handler = new AutoCompleteNicksHandler();
+        AutoCompleteNicksHandler handler = new();
 
 
         Dictionary<string, string> formData = new()
@@ -96,18 +104,21 @@ public class AutoCompleteNicksHandlerTest
     {
         ControllerContext controllerContext = new ControllerContextForTesting();
         using BountyContext bountyContext = controllerContext.HttpContext.RequestServices.GetRequiredService<BountyContext>();
+        ElementUser user = new("", "", "");
         bountyContext.Accounts.AddRange(
             new Account()
             {
-                Name = "korDen"
+                Name = "korDen",
+                User = user,
             },
             new Account()
             {
-                Name = "mrhappyasthma"
+                Name = "mrhappyasthma",
+                User = user,
             });
         await bountyContext.SaveChangesAsync();
 
-        AutoCompleteNicksHandler handler = new AutoCompleteNicksHandler();
+        AutoCompleteNicksHandler handler = new();
 
         Dictionary<string, string> formData = new()
         {

--- a/TRANSMUTANSTEIN/PreAuthHandlerTest.cs
+++ b/TRANSMUTANSTEIN/PreAuthHandlerTest.cs
@@ -38,7 +38,7 @@ public class PreAuthHandlerTest
             new Account()
             {
                 Name = login,
-                User = new(salt, passwordSalt, hashedPassword)
+                User = new(salt, passwordSalt, hashedPassword),
             });
         await bountyContext.SaveChangesAsync();
         ConcurrentDictionary<string, SrpAuthSessionData> srpAuthSessions = new();

--- a/TRANSMUTANSTEIN/TRANSMUTANSTEIN.csproj
+++ b/TRANSMUTANSTEIN/TRANSMUTANSTEIN.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/TRANSMUTANSTEIN/Usings.cs
+++ b/TRANSMUTANSTEIN/Usings.cs
@@ -1,19 +1,25 @@
 // Keep this file alphabetized.
 
 #region Microsoft Using Directives
-global using Microsoft.AspNetCore.Mvc;
-global using Microsoft.EntityFrameworkCore;
-global using Microsoft.EntityFrameworkCore.Storage;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.VisualStudio.TestTools.UnitTesting;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Http.Features;
+global using Microsoft.AspNetCore.Mvc;
+global using Microsoft.Data.Sqlite;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endregion
+
+#region SecureRemotePassword Using Directives
+global using SecureRemotePassword;
 #endregion
 
 #region System Using Directives
 global using System.Collections.Concurrent;
+global using System.Net;
 #endregion
 
 #region ZORGATH Project Using Directives
 global using ZORGATH;
 #endregion
+


### PR DESCRIPTION
Basic in-memory database has a few issues:
- (less important) does not validate constrains (e.g. allows nulls for required data)
- (more important) does not support new EF 7.0 ExecuteUpdate() method (thows Exception), which is used in SrpAuthHandler.

Overall, SQLite is much closer to what we have in production and thus better for testing.