### PR TITLE
Add entities and migrations for Cloud Storage.

### DIFF
--- a/PUZZLEBOX/Account.cs
+++ b/PUZZLEBOX/Account.cs
@@ -30,6 +30,8 @@ public class Account
 
     public Clan.Tier ClanTier { get; set; }
 
+    public CloudStorage? CloudStorage { get; set; }
+
     [Required]
     public DateTime TimestampCreated { get; set; }
 

--- a/PUZZLEBOX/BountyContext.cs
+++ b/PUZZLEBOX/BountyContext.cs
@@ -10,6 +10,8 @@ public class BountyContext : IdentityDbContext<ElementUser>
 
     public DbSet<Clan> Clans { get; set; }
 
+    public DbSet<CloudStorage> CloudStorages { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/PUZZLEBOX/CloudStorage.cs
+++ b/PUZZLEBOX/CloudStorage.cs
@@ -1,0 +1,45 @@
+﻿namespace PUZZLEBOX;
+
+/// <summary>
+///     Stores a user's cloud storage settings and preferences.
+/// </summary>
+public class CloudStorage
+{
+    /// <summary>
+    ///     Primary key identifier for this cloud storage entity.
+    /// </summary>
+    [Key]
+    [Required]
+    public int CloudStorageId { get; set; }
+
+    /// <summary>
+    ///     The ID of the account, be it a master account or a sub-account.
+    /// </summary>
+    [Required]
+    public int AccountId { get; set; }
+
+    /// <summary>
+    ///     Whether the user has selected the option to automatically download
+    ///     cloud settings on log-in.
+    /// </summary>
+    [Required]
+    public bool UseCloud { get; set; } = false;
+
+    /// <summary>
+    ///     Whether the user has selected the option to automatically upload
+    ///     any settings changes to the cloud.
+    /// </summary>
+    [Required]
+    public bool CloudAutoupload { get; set; } = false;
+
+    /// <summary>
+    ///     The timestamp of when the "cloud.zip" was last modified. Extracted
+    ///     from the file upload.
+    /// </summary>
+    public string? FileModifyTime { get; set; }
+
+    /// <summary>
+    ///     The zipfile containing the cloud.cfg that was backed up from the client.
+    /// </summary>
+    public byte[]? CloudCfgZip { get; set; }
+}

--- a/SKELETON-KING/Migrations/20230514200143_CloudStorage.Designer.cs
+++ b/SKELETON-KING/Migrations/20230514200143_CloudStorage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PUZZLEBOX;
 
@@ -11,9 +12,11 @@ using PUZZLEBOX;
 namespace SKELETON_KING.Migrations
 {
     [DbContext(typeof(BountyContext))]
-    partial class BountyContextModelSnapshot : ModelSnapshot
+    [Migration("20230514200143_CloudStorage")]
+    partial class CloudStorage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SKELETON-KING/Migrations/20230514200143_CloudStorage.cs
+++ b/SKELETON-KING/Migrations/20230514200143_CloudStorage.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SKELETON_KING.Migrations
+{
+    /// <inheritdoc />
+    public partial class CloudStorage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CloudStorages",
+                columns: table => new
+                {
+                    CloudStorageId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    AccountId = table.Column<int>(type: "int", nullable: false),
+                    UseCloud = table.Column<bool>(type: "bit", nullable: false),
+                    CloudAutoupload = table.Column<bool>(type: "bit", nullable: false),
+                    FileModifyTime = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CloudCfgZip = table.Column<byte[]>(type: "varbinary(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CloudStorages", x => x.CloudStorageId);
+                    table.ForeignKey(
+                        name: "FK_CloudStorages_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "AccountId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CloudStorages_AccountId",
+                table: "CloudStorages",
+                column: "AccountId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CloudStorages");
+        }
+    }
+}


### PR DESCRIPTION
This is not used yet. The controllers/handlers will come in later PRs.

This just introduces the new rows/columns in the DB.

Tracking bug: https://github.com/N-E-W-E-R-T-H/SKELETON-KING/issues/42