### PR TITLE
A bugfix in PHP.CS that caused floating numbers to be parsed as 1234,…

### DIFF
--- a/ZORGATH/PHP.cs
+++ b/ZORGATH/PHP.cs
@@ -1,4 +1,5 @@
 ﻿namespace ZORGATH;
+using System.Globalization;
 
 /// <summary>
 /// Custom PHP serialization library that focuses on performance while fixing some of the issues that PhpSerializerNET has:
@@ -188,7 +189,7 @@ public class PHP
     {
         sb.Append('d');
         sb.Append(':');
-        sb.Append(value);
+        sb.Append(value.ToString(CultureInfo.InvariantCulture));
         sb.Append(';');
     }
 
@@ -196,7 +197,7 @@ public class PHP
     {
         sb.Append('d');
         sb.Append(':');
-        sb.Append(value);
+        sb.Append(value.ToString(CultureInfo.InvariantCulture));
         sb.Append(';');
     }
 


### PR DESCRIPTION
…567 instead of 1234.567 that also caused the HoN-client to cause an 'invalid data'-error with some windows localizations.